### PR TITLE
Enable devicetree selection from machine config

### DIFF
--- a/recipes-kernel/linux/linux-L4T_3.10.bb
+++ b/recipes-kernel/linux/linux-L4T_3.10.bb
@@ -23,4 +23,4 @@ SRC_URI = "http://developer.download.nvidia.com/embedded/L4T/r21_Release_v4.0/so
 SRC_URI[md5sum] = "bf17f67bbb68cb296d37ff03fa9fde5e"
 SRC_URI[sha256sum] = "737f01305c3fb870eed68c3835728ce3f188052d9c8f321fe69efd1d0f9a455e"
 
-KERNEL_DEVICETREE = "tegra124-jetson_tk1-pm375-000-c00-00.dtb"
+KERNEL_DEVICETREE ?= "tegra124-jetson_tk1-pm375-000-c00-00.dtb"


### PR DESCRIPTION
Hi Watatuki,

I'd like to be able to use a custom device tree by using a definition in machine.conf or local.conf. For this to work, the change attached is needed. It would be great if you could include the change.

Best regards,

Olaf
